### PR TITLE
Use fixed encoding for password instead of system default for stability across platforms

### DIFF
--- a/src/main/java/de/mkammerer/argon2/Argon2i.java
+++ b/src/main/java/de/mkammerer/argon2/Argon2i.java
@@ -30,9 +30,14 @@ class Argon2i implements Argon2 {
      */
     private static final Charset ASCII = Charset.forName("ASCII");
 
+    /**
+     * UTF-8 encoding.
+     */
+    private static final Charset UTF8 = Charset.forName("UTF8");
+
     @Override
     public String hash(int iterations, int memory, int parallelism, String password) {
-        byte[] pwd = password.getBytes();
+        byte[] pwd = password.getBytes(UTF8);
         byte[] salt = generateSalt();
 
         byte[] encoded = new byte[HASH_LENGTH * 4];
@@ -63,7 +68,7 @@ class Argon2i implements Argon2 {
     @Override
     public boolean verify(String hash, String password) {
         byte[] encoded = hash.getBytes(ASCII);
-        byte[] pwd = password.getBytes();
+        byte[] pwd = password.getBytes(UTF8);
 
         int result = Argon2Library.INSTANCE.argon2i_verify(encoded, pwd, new Size_t(pwd.length));
 


### PR DESCRIPTION
Using `getBytes` without arguments is very often a dangerous choice. Things will break if two machines with different default encodings run the same app using this library. Things need to be deterministic across all runs, so a specific encoding must be used.

Having said that, DO NOT MERGE THIS AS IS because that will make things even worse for anyone whose default encoding is not UTF8. Some kind of versioning scheme for backward compatibility needs to be introduced. I'm not sure what the appropriate approach would be. This would probably come in handy for fixing other problems in the future anyway and might as well be introduced.