### PR TITLE
Support for argon2X_hash_raw methods

### DIFF
--- a/src/main/java/de/mkammerer/argon2/Argon2.java
+++ b/src/main/java/de/mkammerer/argon2/Argon2.java
@@ -58,6 +58,60 @@ public interface Argon2 {
     String hash(int iterations, int memory, int parallelism, char[] password, Charset charset);
 
     /**
+     * Hashes a password.
+     *
+     * Uses UTF-8 encoding.
+     *
+     * @param iterations  Number of iterations
+     * @param memory      Sets memory usage to x kibibytes
+     * @param parallelism Number of threads and compute lanes
+     * @param password    Password to hash
+     * @param salt        Salt to use
+     * @return Hashed password.
+     */
+    byte[] rawHash(int iterations, int memory, int parallelism, String password, byte[] salt);
+
+    /**
+     * Hashes a password.
+     *
+     * @param iterations  Number of iterations
+     * @param memory      Sets memory usage to x kibibytes
+     * @param parallelism Number of threads and compute lanes
+     * @param password    Password to hash
+     * @param charset     Charset of the password
+     * @param salt        Salt to use
+     * @return Hashed password.
+     */
+    byte[] rawHash(int iterations, int memory, int parallelism, String password, Charset charset, byte[] salt);
+
+    /**
+     * Hashes a password.
+     *
+     * Uses UTF-8 encoding.
+     *
+     * @param iterations  Number of iterations
+     * @param memory      Sets memory usage to x kibibytes
+     * @param parallelism Number of threads and compute lanes
+     * @param password    Password to hash
+     * @param salt        Salt to use
+     * @return Hashed password.
+     */
+    byte[] rawHash(int iterations, int memory, int parallelism, char[] password, byte[] salt);
+
+    /**
+     * Hashes a password.
+     *
+     * @param iterations  Number of iterations
+     * @param memory      Sets memory usage to x kibibytes
+     * @param parallelism Number of threads and compute lanes
+     * @param password    Password to hash
+     * @param charset     Charset of the password
+     * @param salt        Salt to use
+     * @return Hashed password.
+     */
+    byte[] rawHash(int iterations, int memory, int parallelism, char[] password, Charset charset, byte[] salt);
+
+    /**
      * Verifies a password against a hash.
      *
      * Uses UTF-8 encoding.

--- a/src/main/java/de/mkammerer/argon2/Argon2d.java
+++ b/src/main/java/de/mkammerer/argon2/Argon2d.java
@@ -40,6 +40,14 @@ class Argon2d extends BaseArgon2 {
     }
 
     @Override
+    protected int callLibraryRawHash(byte[] pwd, byte[] salt, Uint32_t iterations, Uint32_t memory, Uint32_t parallelism, byte[] hash) {
+        return Argon2Library.INSTANCE.argon2d_hash_raw(
+                iterations, memory, parallelism, pwd, new Size_t(pwd.length),
+                salt, new Size_t(salt.length), hash, new Size_t(hash.length)
+        );
+    }
+
+    @Override
     protected int callLibraryVerify(byte[] encoded, byte[] pwd) {
         return Argon2Library.INSTANCE.argon2d_verify(encoded, pwd, new Size_t(pwd.length));
     }

--- a/src/main/java/de/mkammerer/argon2/Argon2i.java
+++ b/src/main/java/de/mkammerer/argon2/Argon2i.java
@@ -40,6 +40,14 @@ class Argon2i extends BaseArgon2 {
     }
 
     @Override
+    protected int callLibraryRawHash(byte[] pwd, byte[] salt, Uint32_t iterations, Uint32_t memory, Uint32_t parallelism, byte[] hash) {
+        return Argon2Library.INSTANCE.argon2i_hash_raw(
+                iterations, memory, parallelism, pwd, new Size_t(pwd.length),
+                salt, new Size_t(salt.length), hash, new Size_t(hash.length)
+        );
+    }
+
+    @Override
     protected int callLibraryVerify(byte[] encoded, byte[] pwd) {
         return Argon2Library.INSTANCE.argon2i_verify(encoded, pwd, new Size_t(pwd.length));
     }

--- a/src/main/java/de/mkammerer/argon2/Argon2id.java
+++ b/src/main/java/de/mkammerer/argon2/Argon2id.java
@@ -40,6 +40,14 @@ class Argon2id extends BaseArgon2 {
     }
 
     @Override
+    protected int callLibraryRawHash(byte[] pwd, byte[] salt, Uint32_t iterations, Uint32_t memory, Uint32_t parallelism, byte[] hash) {
+        return Argon2Library.INSTANCE.argon2id_hash_raw(
+                iterations, memory, parallelism, pwd, new Size_t(pwd.length),
+                salt, new Size_t(salt.length), hash, new Size_t(hash.length)
+        );
+    }
+
+    @Override
     protected int callLibraryVerify(byte[] encoded, byte[] pwd) {
         return Argon2Library.INSTANCE.argon2id_verify(encoded, pwd, new Size_t(pwd.length));
     }

--- a/src/main/java/de/mkammerer/argon2/jna/Argon2Library.java
+++ b/src/main/java/de/mkammerer/argon2/jna/Argon2Library.java
@@ -74,6 +74,53 @@ public interface Argon2Library extends Library {
      * @return {@link #ARGON2_OK} if successful
      */
     int argon2d_hash_encoded(Uint32_t t_cost, Uint32_t m_cost, Uint32_t parallelism, byte[] pwd, Size_t pwdlen, byte[] salt, Size_t saltlen, Size_t hashlen, byte[] encoded, Size_t encodedlen);
+    
+    /**
+     * Hashes a password with Argon2i, producing an encoded hash.
+     *
+     * @param t_cost      Number of iterations
+     * @param m_cost      Sets memory usage to m_cost kibibytes
+     * @param parallelism Number of threads and compute lanes
+     * @param pwd         Pointer to password
+     * @param pwdlen      Password size in bytes
+     * @param salt        Pointer to salt
+     * @param saltlen     Salt size in bytes
+     * @param hash        Buffer where to write the raw hash
+     * @param hashlen     Desired length of the hash in bytes
+     * @return {@link #ARGON2_OK} if successful
+     */
+    int argon2i_hash_raw(Uint32_t t_cost, Uint32_t m_cost, Uint32_t parallelism, byte[] pwd, Size_t pwdlen, byte[] salt, Size_t saltlen, byte[] hash, Size_t hashlen);
+
+    /**
+     * Hashes a password with Argon2id, producing an encoded hash.
+     *
+     * @param t_cost      Number of iterations
+     * @param m_cost      Sets memory usage to m_cost kibibytes
+     * @param parallelism Number of threads and compute lanes
+     * @param pwd         Pointer to password
+     * @param pwdlen      Password size in bytes
+     * @param salt        Pointer to salt
+     * @param saltlen     Salt size in bytes
+     * @param hash        Buffer where to write the raw hash
+     * @param hashlen     Desired length of the hash in bytes
+     * @return {@link #ARGON2_OK} if successful
+     */
+    int argon2id_hash_raw(Uint32_t t_cost, Uint32_t m_cost, Uint32_t parallelism, byte[] pwd, Size_t pwdlen, byte[] salt, Size_t saltlen, byte[] hash, Size_t hashlen);
+    /**
+     * Hashes a password with Argon2d, producing an encoded hash.
+     *
+     * @param t_cost      Number of iterations
+     * @param m_cost      Sets memory usage to m_cost kibibytes
+     * @param parallelism Number of threads and compute lanes
+     * @param pwd         Pointer to password
+     * @param pwdlen      Password size in bytes
+     * @param salt        Pointer to salt
+     * @param saltlen     Salt size in bytes
+     * @param hash        Buffer where to write the raw hash
+     * @param hashlen     Desired length of the hash in bytes
+     * @return {@link #ARGON2_OK} if successful
+     */
+    int argon2d_hash_raw(Uint32_t t_cost, Uint32_t m_cost, Uint32_t parallelism, byte[] pwd, Size_t pwdlen, byte[] salt, Size_t saltlen, byte[] hash, Size_t hashlen);
     /**
      * Verifies a password against an Argon2i encoded string.
      *

--- a/src/test/java/de/mkammerer/argon2/test/LibraryTest.java
+++ b/src/test/java/de/mkammerer/argon2/test/LibraryTest.java
@@ -134,7 +134,7 @@ public class LibraryTest {
 
     @Test
     public void testUTF8() throws Exception {
-        String password = "Å§ÒºÃ¬ÅŸ Î¯Å� á»©Å£Æ’-8";
+        String password = "ŧҺìş ίŝ ứţƒ-8";
 
         Argon2 sut = Argon2Factory.create();
         String hash = sut.hash(2, 65535, 1, password, Charset.forName("UTF-8"));

--- a/src/test/java/de/mkammerer/argon2/test/LibraryTest.java
+++ b/src/test/java/de/mkammerer/argon2/test/LibraryTest.java
@@ -1,14 +1,18 @@
 package de.mkammerer.argon2.test;
 
-import de.mkammerer.argon2.Argon2;
-import de.mkammerer.argon2.Argon2Factory;
-import org.junit.Test;
-
-import java.nio.charset.Charset;
-
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
+
+import java.nio.charset.Charset;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.junit.Test;
+
+import de.mkammerer.argon2.Argon2;
+import de.mkammerer.argon2.Argon2Factory;
+import de.mkammerer.argon2.Argon2Factory.Argon2Types;
 
 public class LibraryTest {
     @Test
@@ -130,7 +134,7 @@ public class LibraryTest {
 
     @Test
     public void testUTF8() throws Exception {
-        String password = "ŧҺìş ίŝ ứţƒ-8";
+        String password = "Å§ÒºÃ¬ÅŸ Î¯Å� á»©Å£Æ’-8";
 
         Argon2 sut = Argon2Factory.create();
         String hash = sut.hash(2, 65535, 1, password, Charset.forName("UTF-8"));
@@ -154,5 +158,41 @@ public class LibraryTest {
         for (char c : array) {
             assertThat(c, is((char) 0));
         }
+    }
+    
+    @Test
+    public void testArgon2dRawHash() throws Exception {
+        byte[] salt = new byte[16];
+        ThreadLocalRandom.current().nextBytes(salt);
+        
+        Argon2 sut = Argon2Factory.create(Argon2Types.ARGON2d, salt.length, 32);
+        byte[] hash = sut.rawHash(2, 65536, 1, "password", salt);
+        
+        assertThat(sut.rawHash(2, 65536, 1, "password", salt), is(hash));
+        assertThat(sut.rawHash(2, 65536, 1, "not-the-password", salt), is(not(hash)));
+    }
+
+    @Test
+    public void testArgon2iRawHash() throws Exception {
+        byte[] salt = new byte[16];
+        ThreadLocalRandom.current().nextBytes(salt);
+        
+        Argon2 sut = Argon2Factory.create(Argon2Types.ARGON2i, salt.length, 32);
+        byte[] hash = sut.rawHash(2, 65536, 1, "password", salt);
+        
+        assertThat(sut.rawHash(2, 65536, 1, "password", salt), is(hash));
+        assertThat(sut.rawHash(2, 65536, 1, "not-the-password", salt), is(not(hash)));
+    }
+
+    @Test
+    public void testArgon2idRawHash() throws Exception {
+        byte[] salt = new byte[16];
+        ThreadLocalRandom.current().nextBytes(salt);
+        
+        Argon2 sut = Argon2Factory.create(Argon2Types.ARGON2id, salt.length, 32);
+        byte[] hash = sut.rawHash(2, 65536, 1, "password", salt);
+        
+        assertThat(sut.rawHash(2, 65536, 1, "password", salt), is(hash));
+        assertThat(sut.rawHash(2, 65536, 1, "not-the-password", salt), is(not(hash)));
     }
 }


### PR DESCRIPTION
Added calls to get the raw hash instead of the encoded string. Keeping the hashing parameters separate from the hash is important for my application. I hope you will consider this change.