### PR TITLE
salt_default_charset: add method for string salt with default charset

### DIFF
--- a/src/main/java/de/mkammerer/argon2/Argon2Advanced.java
+++ b/src/main/java/de/mkammerer/argon2/Argon2Advanced.java
@@ -74,4 +74,18 @@ public interface Argon2Advanced extends Argon2 {
      * @return Hashed password.
      */
     String hash(int iterations, int memory, int parallelism, char[] password, Charset charset, byte[] salt);
+
+    /**
+     * Hashes a password, using the given salt.
+     * <p>
+     * Uses UTF-8 encoding.
+     *
+     * @param iterations  Number of iterations
+     * @param memory      Sets memory usage to x kibibytes
+     * @param parallelism Number of threads and compute lanes
+     * @param password    Password to hash
+     * @param salt        Salt to use. This will override the default salt length
+     * @return Hashed password.
+     */
+    String hash(int iterations, int memory, int parallelism, String password, String salt);
 }

--- a/src/main/java/de/mkammerer/argon2/BaseArgon2.java
+++ b/src/main/java/de/mkammerer/argon2/BaseArgon2.java
@@ -102,6 +102,11 @@ abstract class BaseArgon2 implements Argon2, Argon2Advanced {
         return hash(iterations, memory, parallelism, password, DEFAULT_CHARSET);
     }
 
+	@Override
+	public String hash(int iterations, int memory, int parallelism, String password, String salt) {
+		return hash(iterations, memory, parallelism, password.toCharArray(), DEFAULT_CHARSET, salt.getBytes(DEFAULT_CHARSET));
+	}
+
     @Override
     public byte[] rawHash(int iterations, int memory, int parallelism, char[] password, byte[] salt) {
         return rawHash(iterations, memory, parallelism, password, DEFAULT_CHARSET, salt);

--- a/src/test/java/de/mkammerer/argon2/base/AbstractArgonTest.java
+++ b/src/test/java/de/mkammerer/argon2/base/AbstractArgonTest.java
@@ -55,6 +55,17 @@ public abstract class AbstractArgonTest {
     }
 
     @Test
+    public void testWithStringAndSaltString() throws Exception {
+        String salt = new String(createSalt());
+        String hash = sut.hash(ITERATIONS, MEMORY, PARALLELISM, PASSWORD, salt);
+        System.out.println(hash);
+
+        assertThat(hash.startsWith(prefix), is(true));
+        assertThat(sut.verify(hash, PASSWORD), is(true));
+        assertThat(sut.verify(hash, NOT_THE_PASSWORD), is(false));
+    }
+
+    @Test
     public void testWithChars() throws Exception {
         String hash = sut.hash(ITERATIONS, MEMORY, PARALLELISM, PASSWORD.toCharArray());
         System.out.println(hash);


### PR DESCRIPTION
I want calculate hash with default charset for salt.