### PR TITLE
Build a multi-release and provide a module descriptor

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,22 +11,23 @@ on:
 
 
 jobs:
-  buildon-linux:
+  build-on-linux:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        # New gradle doesn't run on <= 8
-        # Java >= 12 doesn't support source/target level 6 anymore
-        java: [ 8, 9, 10, 11 ]
+        # See CONTRIBUTING.md on JDK 11 build requirement
+        java: [ 11 ]
         architecture: [ x86, x64 ]
+        distribution: [ 'zulu', 'adopt' ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
           architecture: ${{ matrix.architecture }}
+          distribution: ${{ matrix.distribution }}
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:
@@ -41,19 +42,20 @@ jobs:
     strategy:
       matrix:
         os: [ macos-latest ]
-        # New gradle doesn't run on <= 8
-        # Java >= 12 doesn't support source/target level 6 anymore
-        java: [ 8, 9, 10, 11 ]
+        # See CONTRIBUTING.md on JDK 11 build requirement
+        java: [ 11 ]
         # MacOS has no support for x86 ("Error: No valid download found for version 11.x and package jdk.")
         architecture: [ x64 ]
+        distribution: [ 'zulu', 'adopt' ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
           architecture: ${{ matrix.architecture }}
+          distribution: ${{ matrix.distribution }}
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:
@@ -68,10 +70,10 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest ]
-        # New gradle doesn't run on <= 8
-        # Java >= 12 doesn't support source/target level 6 anymore
-        java: [ 8, 9, 10, 11 ]
+        # See CONTRIBUTING.md on JDK 11 build requirement
+        java: [ 11 ]
         architecture: [ x86, x64 ]
+        distribution: [ 'zulu', 'adopt' ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -80,6 +82,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           architecture: ${{ matrix.architecture }}
+          distribution: ${{ matrix.distribution }}
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,3 +2,6 @@
 
 Feel free to fork the project and create pull requests. Please use the `develop` branch for new features,
 I like to keep the `master` branch stable.
+
+Note that JDK 11 is required to build. Older versions do not allow creating a Multi-Release JAR and 
+newer versions do not support `--release 6`.

--- a/argon2-jvm-nolibs/build.gradle
+++ b/argon2-jvm-nolibs/build.gradle
@@ -2,16 +2,37 @@ plugins {
     id 'org.sonarqube' version '3.0'
 }
 
+sourceSets {
+    java11 {
+        java {
+            srcDirs = ['src/main/java', 'src/main/java11']
+        }
+    }
+}
+
 jar {
     manifest {
         attributes(
-                'Automatic-Module-Name': 'de.mkammerer.argon2.nolibs'
+                'Automatic-Module-Name': 'de.mkammerer.argon2.nolibs',
+                'Multi-Release': 'true'
         )
+    }
+    into('META-INF/versions/11') {
+        from sourceSets.java11.output
+        exclude('de/**')
     }
 }
 
 dependencies {
     implementation 'net.java.dev.jna:jna:5.8.0'
+}
+
+compileJava11Java {
+    sourceCompatibility = 11
+    targetCompatibility = 11
+    options.compilerArgs.addAll([
+            '--release', '11',
+            '--module-path', sourceSets.main.compileClasspath.asPath]);
 }
 
 sonarqube {

--- a/argon2-jvm-nolibs/src/main/java11/module-info.java
+++ b/argon2-jvm-nolibs/src/main/java11/module-info.java
@@ -1,0 +1,5 @@
+module de.mkammerer.argon2.nolibs {
+    exports de.mkammerer.argon2;
+    exports de.mkammerer.argon2.jna;
+    requires com.sun.jna;
+}

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,10 @@ subprojects {
         options.encoding = 'UTF-8'
     }
 
+    compileJava {
+        options.compilerArgs.addAll(['--release', '6']);
+    }
+
     java {
         sourceCompatibility = JavaVersion.VERSION_1_6
         targetCompatibility = JavaVersion.VERSION_1_6


### PR DESCRIPTION
Uses multi-release jars to add full module-info support. Placing module-info inside META-INF/versions/ is the same approach taken by HikariCP and Log4jJ. Some other libraries like Gson and Lombok simply put it in the root of the jar, but seeing as this library supports JDK 6, care has to be taken to preserve compatibility.

JDK 11 will be required to build argon2-jvm. To ensure compatibility, the `--release` flag is used to prevent calls to newer API methods, which also improves compatibility if you were already building on a newer JDK.

~~This is marked as a draft for now because there is still one issue with the build process I need to work out. Besides module-info.class, every other class is duplicated in META-INF/versions/11, which can be observed with `cd argon2-jvm-nolibs/build/libs && unzip argon2-jvm-nolibs-2.11-SNAPSHOT.jar`. I'll keep wrestling with gradle unless someone else knows a solution.~~

~~Another factor I will investigate is the relation between JNI resources and JPMS. Also, I'm thinking about adding more compatibility tests besides the current one. If one is not careful, adding module-info sometimes breaks features when running on the module path.~~

-------------------------------------

As an unrelated suggestion, have you considered changing the default branch of the repository to master? A previous project I worked on had a non-default dev branch to target PRs to, but it happened several times that PRs were made and even merged to the main/master branch.