### PR TITLE
Feature/argon2 contexts secret and associated data

### DIFF
--- a/argon2-jvm-nolibs/src/main/java/de/mkammerer/argon2/Argon2Advanced.java
+++ b/argon2-jvm-nolibs/src/main/java/de/mkammerer/argon2/Argon2Advanced.java
@@ -135,6 +135,71 @@ public interface Argon2Advanced extends Argon2 {
     HashResult hashAdvanced(int iterations, int memory, int parallelism, byte[] password, byte[] salt, int hashLength, Argon2Version version);
 
     /**
+     * Hashes a password, using the given salt, secret and associated data.
+     *
+     * @param iterations     Number of iterations
+     * @param memory         Sets memory usage to x kibibytes
+     * @param parallelism    Number of threads and compute lanes
+     * @param password       Password to hash
+     * @param charset        Charset of the password
+     * @param salt           Salt
+     * @param secret         Secret (sometimes referred as Pepper)
+     * @param associatedData Associated Data
+     * @return Hashed password in raw bytes.
+     */
+    byte[] rawHashAdvanced(int iterations, int memory, int parallelism, char[] password, Charset charset, byte[] salt, byte[] secret, byte[] associatedData);
+
+    /**
+     * Advanced version of hash, let the caller specify addition parameters such as hash length, salt, secret and associated data.
+     * Return both the encoded and the raw hash.
+     *
+     * @param iterations     Number of iterations
+     * @param memory         Sets memory usage to x kibibytes
+     * @param parallelism    Number of threads and compute lanes
+     * @param password       Password to hash
+     * @param salt           Salt
+     * @param secret         Secret (sometimes referred as Pepper)
+     * @param associatedData Associated Data
+     * @param hashLength     Length of the returned hash in bytes.
+     * @param version        Argon2 version
+     * @return Hashed password in raw bytes.
+     */
+    byte[] rawHashAdvanced(int iterations, int memory, int parallelism, byte[] password, byte[] salt, byte[] secret, byte[] associatedData, int hashLength, Argon2Version version);
+
+    /**
+     * Verifies a password against a hash.
+     *
+     * @param iterations     Number of iterations
+     * @param memory         Sets memory usage to x kibibytes
+     * @param parallelism    Number of threads and compute lanes
+     * @param password       Password to hash
+     * @param charset        Charset of the password
+     * @param salt           Salt
+     * @param secret         Secret (sometimes referred as Pepper)
+     * @param associatedData Associated Data
+     * @param rawHash        Raw Hash bytes.
+     * @return True if the password matches the hash, false otherwise.
+     */
+    boolean verifyAdvanced(int iterations, int memory, int parallelism, char[] password, Charset charset, byte[] salt, byte[] secret, byte[] associatedData, byte[] rawHash);
+
+    /**
+     * Verifies a password against a hash.
+     *
+     * @param iterations     Number of iterations
+     * @param memory         Sets memory usage to x kibibytes
+     * @param parallelism    Number of threads and compute lanes
+     * @param password       Password to hash
+     * @param salt           Salt
+     * @param secret         Secret (sometimes referred as Pepper)
+     * @param associatedData Associated Data
+     * @param hashLength     Length of the returned hash in bytes.
+     * @param version        Argon2 version
+     * @param rawHash        Raw Hash bytes.
+     * @return True if the password matches the hash, false otherwise.
+     */
+    boolean verifyAdvanced(int iterations, int memory, int parallelism, byte[] password, byte[] salt, byte[] secret, byte[] associatedData, int hashLength, Argon2Version version, byte[] rawHash);
+
+    /**
      * Generates salt with the default length.
      *
      * @return Salt.

--- a/argon2-jvm-nolibs/src/main/java/de/mkammerer/argon2/Argon2Version.java
+++ b/argon2-jvm-nolibs/src/main/java/de/mkammerer/argon2/Argon2Version.java
@@ -1,19 +1,28 @@
 package de.mkammerer.argon2;
 
+import de.mkammerer.argon2.jna.Argon2_version;
+
 /**
  * Version of the Argon2 algorithm.
  */
 public enum Argon2Version {
     V10(0x10),
-    V13(0x13);
+    V13(0x13),
+    NUMBER(V13.version);
 
-    private final int jnaVersion;
+    private final int version;
+    private final Argon2_version jnaType;
 
-    Argon2Version(int jnaVersion) {
-        this.jnaVersion = jnaVersion;
+    Argon2Version(int version) {
+        this.version = version;
+        this.jnaType = new Argon2_version(version);
     }
 
-    public int getJnaVersion() {
-        return jnaVersion;
+    public Argon2_version getJnaType() {
+        return jnaType;
+    }
+
+    public int getVersion() {
+        return version;
     }
 }

--- a/argon2-jvm-nolibs/src/main/java/de/mkammerer/argon2/Argon2d.java
+++ b/argon2-jvm-nolibs/src/main/java/de/mkammerer/argon2/Argon2d.java
@@ -1,6 +1,7 @@
 package de.mkammerer.argon2;
 
 import de.mkammerer.argon2.jna.Argon2Library;
+import de.mkammerer.argon2.jna.Argon2_context;
 import de.mkammerer.argon2.jna.JnaUint32;
 import de.mkammerer.argon2.jna.Size_t;
 
@@ -44,5 +45,15 @@ class Argon2d extends BaseArgon2 {
     @Override
     protected int callLibraryVerify(byte[] encoded, byte[] pwd) {
         return Argon2Library.INSTANCE.argon2d_verify(encoded, pwd, new Size_t(pwd.length));
+    }
+
+    @Override
+    protected int callLibraryContext(Argon2_context.ByReference context) {
+        return Argon2Library.INSTANCE.argon2d_ctx(context);
+    }
+
+    @Override
+    protected int callLibraryVerifyContext(Argon2_context.ByReference context, byte[] rawHash) {
+        return Argon2Library.INSTANCE.argon2d_verify_ctx(context, rawHash);
     }
 }

--- a/argon2-jvm-nolibs/src/main/java/de/mkammerer/argon2/Argon2i.java
+++ b/argon2-jvm-nolibs/src/main/java/de/mkammerer/argon2/Argon2i.java
@@ -1,6 +1,7 @@
 package de.mkammerer.argon2;
 
 import de.mkammerer.argon2.jna.Argon2Library;
+import de.mkammerer.argon2.jna.Argon2_context;
 import de.mkammerer.argon2.jna.JnaUint32;
 import de.mkammerer.argon2.jna.Size_t;
 
@@ -44,5 +45,15 @@ class Argon2i extends BaseArgon2 {
     @Override
     protected int callLibraryVerify(byte[] encoded, byte[] pwd) {
         return Argon2Library.INSTANCE.argon2i_verify(encoded, pwd, new Size_t(pwd.length));
+    }
+
+    @Override
+    protected int callLibraryContext(Argon2_context.ByReference context) {
+        return Argon2Library.INSTANCE.argon2i_ctx(context);
+    }
+
+    @Override
+    protected int callLibraryVerifyContext(Argon2_context.ByReference context, byte[] rawHash) {
+        return Argon2Library.INSTANCE.argon2i_verify_ctx(context, rawHash);
     }
 }

--- a/argon2-jvm-nolibs/src/main/java/de/mkammerer/argon2/Argon2id.java
+++ b/argon2-jvm-nolibs/src/main/java/de/mkammerer/argon2/Argon2id.java
@@ -1,6 +1,7 @@
 package de.mkammerer.argon2;
 
 import de.mkammerer.argon2.jna.Argon2Library;
+import de.mkammerer.argon2.jna.Argon2_context;
 import de.mkammerer.argon2.jna.JnaUint32;
 import de.mkammerer.argon2.jna.Size_t;
 
@@ -44,5 +45,15 @@ class Argon2id extends BaseArgon2 {
     @Override
     protected int callLibraryVerify(byte[] encoded, byte[] pwd) {
         return Argon2Library.INSTANCE.argon2id_verify(encoded, pwd, new Size_t(pwd.length));
+    }
+
+    @Override
+    protected int callLibraryContext(Argon2_context.ByReference context) {
+        return Argon2Library.INSTANCE.argon2id_ctx(context);
+    }
+
+    @Override
+    protected int callLibraryVerifyContext(Argon2_context.ByReference context, byte[] rawHash) {
+        return Argon2Library.INSTANCE.argon2id_verify_ctx(context, rawHash);
     }
 }

--- a/argon2-jvm-nolibs/src/main/java/de/mkammerer/argon2/BaseArgon2.java
+++ b/argon2-jvm-nolibs/src/main/java/de/mkammerer/argon2/BaseArgon2.java
@@ -1,7 +1,10 @@
 package de.mkammerer.argon2;
 
+import com.sun.jna.Memory;
 import com.sun.jna.Native;
+import com.sun.jna.Pointer;
 import de.mkammerer.argon2.jna.Argon2Library;
+import de.mkammerer.argon2.jna.Argon2_context;
 import de.mkammerer.argon2.jna.JnaUint32;
 import de.mkammerer.argon2.jna.Size_t;
 
@@ -226,11 +229,51 @@ abstract class BaseArgon2 implements Argon2, Argon2Advanced {
 
         int result = Argon2Library.INSTANCE.argon2_hash(
                 jnaIterations, jnaMemory, jnaParallelism, password, new Size_t(password.length), salt, new Size_t(salt.length),
-                hash, new Size_t(hash.length), encoded, new Size_t(encoded.length), getType().getJnaType(), new JnaUint32(version.getJnaVersion())
+                hash, new Size_t(hash.length), encoded, new Size_t(encoded.length), getType().getJnaType(), version.getJnaType()
         );
         checkResult(result);
 
         return new HashResult(hash, Native.toString(encoded, ASCII));
+    }
+
+    @Override
+    public byte[] rawHashAdvanced(int iterations, int memory, int parallelism, char[] password, Charset charset, byte[] salt, byte[] secret, byte[] associatedData) {
+        byte[] pwd = toByteArray(password, charset);
+        return rawHashAdvanced(iterations, memory, parallelism, pwd, salt, secret, associatedData, defaultHashLength, Argon2Version.NUMBER);
+    }
+
+    @Override
+    public byte[] rawHashAdvanced(int iterations, int memory, int parallelism, byte[] password, byte[] salt, byte[] secret, byte[] associatedData, int hashLength, Argon2Version version) {
+        int length = hashLength > 0 ? hashLength : defaultHashLength;
+        Argon2_context.ByReference context = buildContextReference(iterations, memory, parallelism,
+                length, password, salt, secret, associatedData, version);
+
+        int result = callLibraryContext(context);
+        checkResult(result);
+
+        return context.out.getByteArray(0, length);
+    }
+
+    @Override
+    public boolean verifyAdvanced(int iterations, int memory, int parallelism, char[] password, Charset charset, byte[] salt, byte[] secret, byte[] associatedData, byte[] rawHash) {
+        byte[] pwd = toByteArray(password, charset);
+        return verifyAdvanced(iterations, memory, parallelism, pwd, salt, secret, associatedData, defaultHashLength, Argon2Version.NUMBER, rawHash);
+    }
+
+    @Override
+    public boolean verifyAdvanced(int iterations, int memory, int parallelism, byte[] password, byte[] salt, byte[] secret, byte[] associatedData, int hashLength, Argon2Version version, byte[] rawHash) {
+        int length = hashLength > 0 ? hashLength : defaultHashLength;
+        Argon2_context.ByReference context = buildContextReference(iterations, memory, parallelism,
+                length, password, salt, secret, associatedData, version);
+
+        int result = callLibraryVerifyContext(context, rawHash);
+
+        // skip the result check for error code VERIFY_MISMATCH as this should simply return false instead of throwing an exception.
+        if (result != -35) {
+            checkResult(result);
+        }
+
+        return result == 0;
     }
 
     @Override
@@ -297,6 +340,23 @@ abstract class BaseArgon2 implements Argon2, Argon2Advanced {
      */
     protected abstract int callLibraryVerify(byte[] encoded, byte[] pwd);
 
+    /**
+     * Is called when the ctx hash function of the native library should be called.
+     *
+     * @param context Pointer to one Argon2 context.
+     * @return Return code.
+     */
+    protected abstract int callLibraryContext(Argon2_context.ByReference context);
+
+    /**
+     * Is called when the ctx verify function of the native library should be called.
+     *
+     * @param context Pointer to one Argon2 context.
+     * @param rawHash Raw hash.
+     * @return Return code.
+     */
+    protected abstract int callLibraryVerifyContext(Argon2_context.ByReference context, byte[] rawHash);
+
     private String hashBytes(int iterations, int memory, int parallelism, byte[] pwd) {
         byte[] salt = generateSalt();
         return hashBytes(iterations, memory, parallelism, pwd, salt);
@@ -352,7 +412,7 @@ abstract class BaseArgon2 implements Argon2, Argon2Advanced {
      * @param charset Charset of the password
      * @return UTF-8 encoded byte array
      */
-    private byte[] toByteArray(char[] chars, Charset charset) {
+    private static byte[] toByteArray(char[] chars, Charset charset) {
         assert chars != null;
 
         CharBuffer charBuffer = CharBuffer.wrap(chars);
@@ -361,5 +421,71 @@ abstract class BaseArgon2 implements Argon2, Argon2Advanced {
                 byteBuffer.position(), byteBuffer.limit());
         Arrays.fill(byteBuffer.array(), (byte) 0); // clear sensitive data
         return bytes;
+    }
+
+    /**
+     * Builds a {@link Argon2_context} by the specified arguments.
+     *
+     * @param iterations     Iterations.
+     * @param memory         Memory.
+     * @param parallelism    Parallelism.
+     * @param hashLength     Hash length.
+     * @param password       Password.
+     * @param salt           Salt (nullable).
+     * @param secret         Secret (nullable).
+     * @param associatedData Associated Data (nullable).
+     * @param version        Version (nullable).
+     * @return {@link Argon2_context}
+     */
+    private static Argon2_context.ByReference buildContextReference(int iterations, int memory, int parallelism, int hashLength, byte[] password, byte[] salt, byte[] secret, byte[] associatedData, Argon2Version version) {
+        Argon2_context.ByReference context = new Argon2_context.ByReference();
+
+        context.out = new Memory(hashLength);
+        context.outlen = new JnaUint32(hashLength);
+
+        context.pwd = new Memory(password.length);
+        context.pwd.write(0, password, 0, password.length);
+        context.pwdlen = new JnaUint32(password.length);
+
+        if (salt != null) {
+            context.salt = new Memory(salt.length);
+            context.salt.write(0, salt, 0, salt.length);
+            context.saltlen = new JnaUint32(salt.length);
+        } else {
+            context.salt = Pointer.NULL;
+            context.saltlen = new JnaUint32(0);
+        }
+
+        if (secret != null) {
+            context.secret = new Memory(secret.length);
+            context.secret.write(0, secret, 0, secret.length);
+            context.secretlen = new JnaUint32(secret.length);
+        } else {
+            context.secret = Pointer.NULL;
+            context.secretlen = new JnaUint32(0);
+        }
+
+        if (associatedData != null) {
+            context.ad = new Memory(associatedData.length);
+            context.ad.write(0, associatedData, 0, associatedData.length);
+            context.adlen = new JnaUint32(associatedData.length);
+        } else {
+            context.ad = Pointer.NULL;
+            context.adlen = new JnaUint32(0);
+        }
+
+        context.t_cost = new JnaUint32(iterations);
+        context.m_cost = new JnaUint32(memory);
+        context.lanes = new JnaUint32(parallelism);
+        context.threads = new JnaUint32(parallelism);
+
+        context.version = version.getJnaType();
+
+        context.allocate_cbk = Pointer.NULL;
+        context.free_cbk = Pointer.NULL;
+
+        context.flags = new JnaUint32(0);
+
+        return context;
     }
 }

--- a/argon2-jvm-nolibs/src/main/java/de/mkammerer/argon2/jna/Argon2Library.java
+++ b/argon2-jvm-nolibs/src/main/java/de/mkammerer/argon2/jna/Argon2Library.java
@@ -124,19 +124,6 @@ public interface Argon2Library extends Library {
      */
     int argon2d_hash_raw(JnaUint32 t_cost, JnaUint32 m_cost, JnaUint32 parallelism, byte[] pwd, Size_t pwdlen, byte[] salt, Size_t saltlen, byte[] hash, Size_t hashlen);
 
-    /**
-     * Verifies a password against an Argon2i encoded string.
-     *
-     * @param encoded String encoding parameters, salt, hash
-     * @param pwd     Pointer to password
-     * @param pwdlen  Password size in bytes
-     * @return ARGON2_OK if successful
-     */
-    /*
-    int argon2i_verify(const char *encoded, const void *pwd, const size_t pwdlen);
-     */
-    int argon2i_verify(byte[] encoded, byte[] pwd, Size_t pwdlen);
-
     /*
     ARGON2_PUBLIC int argon2_hash(const uint32_t t_cost, const uint32_t m_cost,
                               const uint32_t parallelism, const void *pwd,
@@ -146,7 +133,17 @@ public interface Argon2Library extends Library {
                               const size_t encodedlen, argon2_type type,
                               const uint32_t version);
      */
-    int argon2_hash(JnaUint32 t_cost, JnaUint32 m_cost, JnaUint32 parallelism, byte[] pwd, Size_t pwdlen, byte[] salt, Size_t saltlen, byte[] hash, Size_t hashlen, byte[] encoded, Size_t encodedlen, Argon2_type type, JnaUint32 version);
+    int argon2_hash(JnaUint32 t_cost, JnaUint32 m_cost, JnaUint32 parallelism, byte[] pwd, Size_t pwdlen, byte[] salt, Size_t saltlen, byte[] hash, Size_t hashlen, byte[] encoded, Size_t encodedlen, Argon2_type type, Argon2_version version);
+
+    /**
+     * Verifies a password against an Argon2i encoded string.
+     *
+     * @param encoded String encoding parameters, salt, hash
+     * @param pwd     Pointer to password
+     * @param pwdlen  Password size in bytes
+     * @return ARGON2_OK if successful
+     */
+    int argon2i_verify(byte[] encoded, byte[] pwd, Size_t pwdlen);
 
     /**
      * Verifies a password against an Argon2d encoded string.
@@ -167,6 +164,84 @@ public interface Argon2Library extends Library {
      * @return ARGON2_OK if successful
      */
     int argon2id_verify(byte[] encoded, byte[] pwd, Size_t pwdlen);
+
+    /*
+    ARGON2_PUBLIC int argon2_verify(const char *encoded, const void *pwd,
+                                const size_t pwdlen, argon2_type type);
+     */
+    int argon2_verify(byte[] encoded, byte[] pwd, Size_t pwdlen, Argon2_type type);
+
+    /**
+     * Argon2d: Version of Argon2 that picks memory blocks depending
+     * on the password and salt. Only for side-channel-free
+     * environment!!
+     *
+     * @param context Pointer to current Argon2 context
+     * @return Zero if successful, a non zero error code otherwise
+     */
+    int argon2i_ctx(Argon2_context.ByReference context);
+
+    /**
+     * Argon2i: Version of Argon2 that picks memory blocks
+     * independent on the password and salt. Good for side-channels,
+     * but worse w.r.t. tradeoff attacks if only one pass is used.
+     *
+     * @param contexts Pointer to current Argon2 context
+     * @return Zero if successful, a non zero error code otherwise
+     */
+    int argon2d_ctx(Argon2_context.ByReference contexts);
+
+    /**
+     * Argon2id: Version of Argon2 where the first half-pass over memory is
+     * password-independent, the rest are password-dependent (on the password and
+     * salt). OK against side channels (they reduce to 1/2-pass Argon2i), and
+     * better with w.r.t. tradeoff attacks (similar to Argon2d).
+     *
+     * @param contexts Pointer to current Argon2 context
+     * @return Zero if successful, a non zero error code otherwise
+     */
+    int argon2id_ctx(Argon2_context.ByReference contexts);
+
+    /*
+    ARGON2_PUBLIC int argon2_ctx(argon2_context *context, argon2_type type);
+     */
+    int argon2_ctx(Argon2_context.ByReference context, Argon2_type type);
+
+    /**
+     * Verify if a given password is correct for Argon2d hashing
+     *
+     * @param context Pointer to current Argon2 context
+     * @param hash    The password hash to verify. The length of the hash is
+     *                specified by the context outlen member
+     * @return Zero if successful, a non zero error code otherwise
+     */
+    int argon2i_verify_ctx(Argon2_context.ByReference context, byte[] hash);
+
+    /**
+     * Verify if a given password is correct for Argon2i hashing
+     *
+     * @param context Pointer to current Argon2 context
+     * @param hash    The password hash to verify. The length of the hash is
+     *                specified by the context outlen member
+     * @return Zero if successful, a non zero error code otherwise
+     */
+    int argon2d_verify_ctx(Argon2_context.ByReference context, byte[] hash);
+
+    /**
+     * Verify if a given password is correct for Argon2id hashing
+     *
+     * @param context Pointer to current Argon2 context
+     * @param hash    The password hash to verify. The length of the hash is
+     *                specified by the context outlen member
+     * @return Zero if successful, a non zero error code otherwise
+     */
+    int argon2id_verify_ctx(Argon2_context.ByReference context, byte[] hash);
+
+    /*
+    ARGON2_PUBLIC int argon2_verify_ctx(argon2_context *context, const char *hash,
+                                        argon2_type type);
+    */
+    int argon2_verify_ctx(Argon2_context.ByReference contexts, byte[] hash, Argon2_version version);
 
     /**
      * Returns the encoded hash length for the given input parameters.

--- a/argon2-jvm-nolibs/src/main/java/de/mkammerer/argon2/jna/Argon2_context.java
+++ b/argon2-jvm-nolibs/src/main/java/de/mkammerer/argon2/jna/Argon2_context.java
@@ -1,0 +1,90 @@
+package de.mkammerer.argon2.jna;
+
+import com.sun.jna.Pointer;
+import com.sun.jna.Structure;
+
+import static com.sun.jna.Structure.FieldOrder;
+
+/**
+ * Argon2_context for C interaction.
+ */
+@FieldOrder({"out", "outlen", "pwd", "pwdlen", "salt", "saltlen", "secret", "secretlen", "ad", "adlen", "t_cost", "m_cost", "lanes", "threads", "version", "allocate_cbk", "free_cbk", "flags"})
+public class Argon2_context extends Structure {
+
+    /**
+     * output array
+     */
+    public Pointer out = null;
+    /**
+     * digest length
+     */
+    public JnaUint32 outlen = new JnaUint32(0);
+    /**
+     * password array
+     */
+    public Pointer pwd = null;
+    /**
+     * password length
+     */
+    public JnaUint32 pwdlen = new JnaUint32(0);
+    /**
+     * salt array
+     */
+    public Pointer salt = null;
+    /**
+     * salt length
+     */
+    public JnaUint32 saltlen = new JnaUint32(0);
+    /**
+     * key array
+     */
+    public Pointer secret = null;
+    /**
+     * key length
+     */
+    public JnaUint32 secretlen = new JnaUint32(0);
+    /**
+     * associated data array
+     */
+    public Pointer ad = null;
+    /**
+     * associated data length
+     */
+    public JnaUint32 adlen = new JnaUint32(0);
+    /**
+     * number of passes
+     */
+    public JnaUint32 t_cost;
+    /**
+     * amount memory of requested (KB)
+     */
+    public JnaUint32 m_cost;
+    /**
+     * number of lanes
+     */
+    public JnaUint32 lanes;
+    /**
+     * maximum number of threads
+     */
+    public JnaUint32 threads;
+    /**
+     * version number
+     */
+    public Argon2_version version;
+    /**
+     * pointer to memory allocator
+     */
+    public Pointer allocate_cbk = Pointer.NULL;
+    /**
+     * pointer to memory deallocator
+     */
+    public Pointer free_cbk = Pointer.NULL;
+    /**
+     * array of bool options
+     */
+    public JnaUint32 flags = new JnaUint32(0);
+
+    public static class ByReference extends Argon2_context implements Structure.ByReference {
+        // empty body
+    }
+}

--- a/argon2-jvm-nolibs/src/main/java/de/mkammerer/argon2/jna/Argon2_version.java
+++ b/argon2-jvm-nolibs/src/main/java/de/mkammerer/argon2/jna/Argon2_version.java
@@ -1,0 +1,25 @@
+package de.mkammerer.argon2.jna;
+
+import de.mkammerer.argon2.Argon2Version;
+
+/**
+ * argon2_type type for C interaction.
+ */
+public class Argon2_version extends JnaUint32 {
+
+    /**
+     * Constructor.
+     *
+     * @param version Version.
+     */
+    public Argon2_version(int version) {
+        super(version);
+    }
+
+    /**
+     * Constructor.
+     */
+    public Argon2_version() {
+        this(Argon2Version.NUMBER.getVersion());
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ subprojects {
     }
 
     java {
-        sourceCompatibility = JavaVersion.VERSION_1_6
-        targetCompatibility = JavaVersion.VERSION_1_6
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
 
         withJavadocJar()
         withSourcesJar()

--- a/compatibility-tests/build.gradle
+++ b/compatibility-tests/build.gradle
@@ -8,8 +8,8 @@ repositories {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_6
-    targetCompatibility = JavaVersion.VERSION_1_6
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 dependencies {


### PR DESCRIPTION
I've added some advanced hash and verify methods to support argon2's secret and associated data.
I needed this for one of my projects and also saw issue #83.

Added:
 - `Argon2_context` `Structure` Class as the representation of its `C struct`.
 - `Argon2_version` as a better representation of its C counterpart.
 - The C `argon2*_ctx(argon2_context *context);` methods to `Argon2Library` class.
 - 2 `rawHashAdvanced` and `verifyAdvanced` methods to `Argon2Advanced` because the `argon2*_ctx(argon2_context *context);` methods do not encode the hash.
 - Also `callLibraryContext` and `callLibrarayVerifyContext` methods to `BaseArgon2`, `Argon2i`, `Argon2d`, and `Argon2id` to support the new native library calls.
 - Minor private helper methods in `BaseArgon2`.
 - Some tests for the new methods.

Modified:
- JavaVersion from 1.6 to 1.8 as my `gradle` wouldn't compile the project otherwise.
- `Argon2Version` to fit the new `Argon2_version` `JnaUint32` class.

Testing:
- I've tested the new methods with the added tests but only on a Linux x64 machine (running ArchLinux) and they worked so far.

As this is one of my first real Github contributions feedback is much appreciated.