### PR TITLE
Record module version and mark dependency on jna as transitive

### DIFF
--- a/argon2-jvm-nolibs/build.gradle
+++ b/argon2-jvm-nolibs/build.gradle
@@ -19,7 +19,7 @@ jar {
     }
     into('META-INF/versions/11') {
         from sourceSets.java11.output
-        exclude('de/**')
+        include('module-info.class')
     }
 }
 
@@ -32,7 +32,8 @@ compileJava11Java {
     targetCompatibility = 11
     options.compilerArgs.addAll([
             '--release', '11',
-            '--module-path', sourceSets.main.compileClasspath.asPath]);
+            '--module-path', sourceSets.main.compileClasspath.asPath,
+            '--module-version', project.version]);
 }
 
 sonarqube {

--- a/argon2-jvm-nolibs/src/main/java11/module-info.java
+++ b/argon2-jvm-nolibs/src/main/java11/module-info.java
@@ -1,5 +1,5 @@
 module de.mkammerer.argon2.nolibs {
     exports de.mkammerer.argon2;
     exports de.mkammerer.argon2.jna;
-    requires com.sun.jna;
+    requires transitive com.sun.jna;
 }


### PR DESCRIPTION
Sorry for breaking the CI with the last PR. This one is much less disruptive.

Adding the module version is a cool little feature which helps with nicer-looking stacktraces.

The transitive requirement on JNA is something I should have added before. It's not a strict requirement but is the right way to declare such dependencies for correctness's sake.