### PR TITLE
Correct resources path in docs for compiling lib yourself

### DIFF
--- a/docs/compile-argon2.md
+++ b/docs/compile-argon2.md
@@ -7,7 +7,7 @@
 5. Set the Java system property `jna.library.path` to the directory where your library is stored. Example: The library is located in `/home/moe/tmp/phc-winner-argon2/libargon2.so`. Start your Java application with `-Djna.library.path=/home/moe/tmp/phc-winner-argon2/`
 6. If it doesn't work, set the Java system property `jna.debug_load` to `true`. This will print JNA library lookup details to the console. Example: `-Djna.debug_load=true`
 
-You can make it available to JNA by placing them under your `resources/{OS}_{ARCH}`. In this case you don't need to use any extra system property.
+You can make it available to JNA by placing them under your `resources/{OS}-{ARCH}`. In this case you don't need to use any extra system property.
 Check the [JNA getting started guide](https://github.com/java-native-access/jna/blob/master/www/GettingStarted.md) for details.
 
 ## Install it on your local system


### PR DESCRIPTION
If you compile the library yourself and want to put it in the resources directory, the correct naming scheme is `resource/{OS}-{ARCH}`, as can be looked up in the [JNA Getting started guide](https://github.com/java-native-access/jna/blob/master/www/GettingStarted.md).

Thought since this is only docs, this should go straight to master and not on dev.